### PR TITLE
logの取得をコールバックではなくintervalにした

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "react-slider": "^2.0.6",
         "react-switch": "^7.0.0",
         "three": "^0.167.1",
-        "webcface": "^1.7.0",
+        "webcface": "^1.8.0",
         "webgl-plot": "^0.7.1"
       },
       "devDependencies": {
@@ -1014,11 +1014,6 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
       "dev": true
-    },
-    "node_modules/@log4js-node/log4js-api": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@log4js-node/log4js-api/-/log4js-api-1.0.2.tgz",
-      "integrity": "sha512-6SJfx949YEWooh/CUPpJ+F491y4BYJmknz4hUN1+RHvKoUEynKbRmhnwbk/VLmh4OthLLDNCyWXfbh4DG1cTXA=="
     },
     "node_modules/@malept/cross-spawn-promise": {
       "version": "1.1.1",
@@ -2328,7 +2323,8 @@
     "node_modules/@ygoe/msgpack": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@ygoe/msgpack/-/msgpack-1.0.3.tgz",
-      "integrity": "sha512-Sjp0O/sNgOJxTOO1c2Zuu7nsHRIGu2iGPYyhUedKKbcHyUl73jbCaomEFJZHNb/6i94B+ZNZHVnFgpo0ENSXxQ=="
+      "integrity": "sha512-Sjp0O/sNgOJxTOO1c2Zuu7nsHRIGu2iGPYyhUedKKbcHyUl73jbCaomEFJZHNb/6i94B+ZNZHVnFgpo0ENSXxQ==",
+      "license": "MIT"
     },
     "node_modules/7zip-bin": {
       "version": "5.2.0",
@@ -2723,20 +2719,6 @@
         "postcss": "^8.1.0"
       }
     },
-    "node_modules/available-typed-arrays": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
-      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-      "dependencies": {
-        "possible-typed-array-names": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2921,6 +2903,7 @@
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.8.tgz",
       "integrity": "sha512-4T53u4PdgsXqKaIctwF8ifXlRTTmEPJ8iEPWFdGZvcf7sbwYo6FKFEX9eNNAnzFZ7EzJAQ3CJeOtCRA4rDp7Pw==",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -3025,24 +3008,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/call-bind": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -3627,6 +3592,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
       "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
+      "license": "ISC",
       "dependencies": {
         "es5-ext": "^0.10.64",
         "type": "^2.7.2"
@@ -3644,14 +3610,6 @@
         "url": "https://github.com/sponsors/kossnocorp"
       }
     },
-    "node_modules/date-format": {
-      "version": "4.0.14",
-      "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.14.tgz",
-      "integrity": "sha512-39BOQLs9ZjKh0/patS9nrT8wc3ioX3/eA/zgbKNopnF2wCqJEoxywwwElATYvRsXdnOxA/OQeQoFZ3rFjVajhg==",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/debounce": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
@@ -3661,6 +3619,7 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
       "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -3724,6 +3683,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "optional": true,
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -4226,6 +4187,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
       "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "dev": true,
+      "optional": true,
       "dependencies": {
         "get-intrinsic": "^1.2.4"
       },
@@ -4237,6 +4200,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -4246,6 +4211,7 @@
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
       "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
       "hasInstallScript": true,
+      "license": "ISC",
       "dependencies": {
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.3",
@@ -4267,6 +4233,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+      "license": "MIT",
       "dependencies": {
         "d": "1",
         "es5-ext": "^0.10.35",
@@ -4277,6 +4244,7 @@
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
       "integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
+      "license": "ISC",
       "dependencies": {
         "d": "^1.0.2",
         "ext": "^1.7.0"
@@ -4466,6 +4434,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
       "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+      "license": "ISC",
       "dependencies": {
         "d": "^1.0.1",
         "es5-ext": "^0.10.62",
@@ -4548,6 +4517,7 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+      "license": "MIT",
       "dependencies": {
         "d": "1",
         "es5-ext": "~0.10.14"
@@ -4556,12 +4526,14 @@
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
     },
     "node_modules/ext": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
       "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+      "license": "ISC",
       "dependencies": {
         "type": "^2.7.2"
       }
@@ -4759,15 +4731,8 @@
     "node_modules/flatted": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
-      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
-    },
-    "node_modules/for-each": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-      "dependencies": {
-        "is-callable": "^1.1.3"
-      }
+      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
+      "dev": true
     },
     "node_modules/foreground-child": {
       "version": "3.1.1",
@@ -4822,6 +4787,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
       "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^4.0.0",
@@ -4879,6 +4845,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -4896,6 +4863,8 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
       "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+      "dev": true,
+      "optional": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
@@ -5030,6 +4999,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
       "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
+      "optional": true,
       "dependencies": {
         "get-intrinsic": "^1.1.3"
       },
@@ -5065,7 +5036,8 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -5098,6 +5070,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "optional": true,
       "dependencies": {
         "es-define-property": "^1.0.0"
       },
@@ -5109,6 +5083,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
       "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -5120,20 +5096,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
+      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -5145,6 +5109,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
       "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "dev": true,
+      "optional": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -5305,22 +5271,8 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "node_modules/is-arguments": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -5332,17 +5284,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-callable": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-ci": {
@@ -5387,20 +5328,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-generator-function": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
-      "dependencies": {
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -5431,24 +5358,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-typed-array": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
-      "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
-      "dependencies": {
-        "which-typed-array": "^1.1.14"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "license": "MIT"
     },
     "node_modules/isarray": {
       "version": "1.0.0",
@@ -5602,6 +5516,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -5792,21 +5707,6 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
       "dev": true
-    },
-    "node_modules/log4js": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.9.1.tgz",
-      "integrity": "sha512-1somDdy9sChrr9/f4UlzhdaGfDR2c/SaD2a4T7qEkG4jTS57/B3qmnjLYePwQ8cqWnUHZI0iAKxMBpCZICiZ2g==",
-      "dependencies": {
-        "date-format": "^4.0.14",
-        "debug": "^4.3.4",
-        "flatted": "^3.2.7",
-        "rfdc": "^1.3.0",
-        "streamroller": "^3.1.5"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -6021,7 +5921,8 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -6061,7 +5962,8 @@
     "node_modules/next-tick": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
+      "license": "ISC"
     },
     "node_modules/node-addon-api": {
       "version": "1.7.2",
@@ -6071,9 +5973,10 @@
       "optional": true
     },
     "node_modules/node-gyp-build": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.0.tgz",
-      "integrity": "sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.2.tgz",
+      "integrity": "sha512-IRUxE4BVsHWXkV/SFOut4qTlagw2aM8T5/vnTsmrHJvVoKueJHRc/JaFND7QDDc61kLYUJ6qlZM3sqTSyx2dTw==",
+      "license": "MIT",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -6353,14 +6256,6 @@
       },
       "engines": {
         "node": ">=10.4.0"
-      }
-    },
-    "node_modules/possible-typed-array-names": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
-      "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
@@ -7348,11 +7243,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/rfdc": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.1.tgz",
-      "integrity": "sha512-r5a3l5HzYlIC68TpmYKlxWjmOP6wiPJ1vWv2HeLhNsRZMrCkxeqxiHlQ21oXmQ4F3SiryXBHhAD7JZqvOJjFmg=="
-    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -7547,22 +7437,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/set-function-length": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -7685,19 +7559,6 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/streamroller": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.1.5.tgz",
-      "integrity": "sha512-KFxaM7XT+irxvdqSP1LGLgNWbYN7ay5owZ3r/8t77p+EtSUAfUgtl7be3xtqtOmGUl9K9YPO2ca8133RlTjvKw==",
-      "dependencies": {
-        "date-format": "^4.0.14",
-        "debug": "^4.3.4",
-        "fs-extra": "^8.1.0"
-      },
-      "engines": {
-        "node": ">=8.0"
       }
     },
     "node_modules/string_decoder": {
@@ -8133,9 +7994,10 @@
       "dev": true
     },
     "node_modules/type": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
-      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
+      "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
+      "license": "ISC"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -8174,6 +8036,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "license": "MIT",
       "dependencies": {
         "is-typedarray": "^1.0.0"
       }
@@ -8201,6 +8064,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -8249,6 +8113,7 @@
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
       "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -8261,18 +8126,6 @@
       "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
       "integrity": "sha512-4+wkEYLBbWxqTahEsWrhxepcoVOJ+1z5PGIjPZxRkytcdSUaNjIjBM7Xn8E+pdSuV7SzvWovBFA54FO0JSoqhA==",
       "dev": true
-    },
-    "node_modules/util": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "is-typed-array": "^1.1.3",
-        "which-typed-array": "^1.1.2"
-      }
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -8379,45 +8232,19 @@
       "dev": true
     },
     "node_modules/webcface": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/webcface/-/webcface-1.7.0.tgz",
-      "integrity": "sha512-XvUQc8B44mM13gCnDVR6nL+J3m5ZKQtuk7kLmt2Oy2ycoAeVb1+UCzM48w+dKhuK6JQ8MzEsclPqLzPrlOpsOg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/webcface/-/webcface-1.8.0.tgz",
+      "integrity": "sha512-TLZERP3Rt1TgCqRJ05hSbEFjxP5bpu9Qn6CCrF9drHHd4kLGnn9an8oauMfsVEG4ZN5tsk4HBg/f3u7NhxED5g==",
       "license": "MIT",
       "dependencies": {
-        "@log4js-node/log4js-api": "^1.0.2",
         "@ygoe/msgpack": "^1.0.3",
         "eventemitter3": "^5.0.1",
         "lodash.isequal": "^4.5.0",
-        "log4js": "^6.9.1",
         "mathjs": "^13.0.1",
-        "util": "^0.12.5",
         "websocket": "^1.0.34"
       },
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/webcface/node_modules/mathjs": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-13.1.1.tgz",
-      "integrity": "sha512-duaSAy7m4F+QtP1Dyv8MX2XuxcqpNDDlGly0SdVTCqpAmwdOFWilDdQKbLdo9RfD6IDNMOdo9tIsEaTXkconlQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/runtime": "^7.25.4",
-        "complex.js": "^2.1.1",
-        "decimal.js": "^10.4.3",
-        "escape-latex": "^1.2.0",
-        "fraction.js": "^4.3.7",
-        "javascript-natural-sort": "^0.7.1",
-        "seedrandom": "^3.0.5",
-        "tiny-emitter": "^2.1.0",
-        "typed-function": "^4.2.1"
-      },
-      "bin": {
-        "mathjs": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">= 18"
       }
     },
     "node_modules/webgl-plot": {
@@ -8426,13 +8253,14 @@
       "integrity": "sha512-CSLgEj+Xerd+SZoBpIWMiHk/AhoPb8ZokqmTGPaGOra0++9e5LsiAWIuUWGunOHjllvKAhSKPg7yG4+kiHifew=="
     },
     "node_modules/websocket": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.34.tgz",
-      "integrity": "sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==",
+      "version": "1.0.35",
+      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.35.tgz",
+      "integrity": "sha512-/REy6amwPZl44DDzvRCkaI1q1bIiQB0mEFQLUrhz3z2EK91cp3n72rAjUlrTP0zV22HJIUOVHQGPxhFRjxjt+Q==",
+      "license": "Apache-2.0",
       "dependencies": {
         "bufferutil": "^4.0.1",
         "debug": "^2.2.0",
-        "es5-ext": "^0.10.50",
+        "es5-ext": "^0.10.63",
         "typedarray-to-buffer": "^3.1.5",
         "utf-8-validate": "^5.0.2",
         "yaeti": "^0.0.6"
@@ -8445,6 +8273,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -8452,7 +8281,8 @@
     "node_modules/websocket/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -8467,24 +8297,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/which-typed-array": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
-      "integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
-      "dependencies": {
-        "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.7",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/wrap-ansi": {
@@ -8550,6 +8362,7 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
       "integrity": "sha512-MvQa//+KcZCUkBTIC9blM+CU9J2GzuTytsOUwf2lidtvkx/6gnEp1QvJv34t9vdjhFmha/mUiNDbN0D0mJWdug==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.32"
       }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "react-slider": "^2.0.6",
     "react-switch": "^7.0.0",
     "three": "^0.167.1",
-    "webcface": "^1.7.0",
+    "webcface": "^1.8.0",
     "webgl-plot": "^0.7.1"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,7 +75,7 @@ export default function App() {
         window.electronAPI?.sp.offLogAppend(onLogAppend);
       };
     }
-  }, []);
+  }, [logStore.serverData, logStore.serverHasUpdate]);
 
   const [menuOpen, setMenuOpen] = useState<boolean>(false);
 

--- a/src/components/canvas2DCard.tsx
+++ b/src/components/canvas2DCard.tsx
@@ -23,6 +23,7 @@ interface Props {
   canvas: Canvas2D;
 }
 export function Canvas2DCard(props: Props) {
+  const { layoutChanging } = useLayoutChange();
   const divRef = useRef<HTMLDivElement>(null);
   const [divWidth, setDivWidth] = useState<number>(0);
   const [divHeight, setDivHeight] = useState<number>(0);
@@ -35,34 +36,36 @@ export function Canvas2DCard(props: Props) {
   const [moveEnabled, setMoveEnabled] = useState<boolean>(false);
 
   useEffect(() => {
-    const i = setInterval(() => {
-      if (hasUpdate.current) {
-        update();
-        hasUpdate.current = false;
-      }
-      if (
-        divRef.current?.clientWidth !== divWidth ||
-        divRef.current?.clientHeight !== divHeight ||
-        canvas2dWidth.current !== props.canvas.width ||
-        canvas2dHeight.current !== props.canvas.height
-      ) {
-        if (divRef.current) {
-          setDivWidth(divRef.current.clientWidth);
-          setDivHeight(divRef.current.clientHeight);
+    if (!layoutChanging) {
+      const i = setInterval(() => {
+        if (hasUpdate.current) {
+          update();
+          hasUpdate.current = false;
         }
-        if (props.canvas.width && props.canvas.height) {
-          canvas2dWidth.current = props.canvas.width;
-          canvas2dHeight.current = props.canvas.height;
-          const xRatio =
-            (divRef.current?.clientWidth || 0) / props.canvas.width;
-          const yRatio =
-            (divRef.current?.clientHeight || 0) / props.canvas.height;
-          setRatio(Math.min(xRatio, yRatio));
+        if (
+          divRef.current?.clientWidth !== divWidth ||
+          divRef.current?.clientHeight !== divHeight ||
+          canvas2dWidth.current !== props.canvas.width ||
+          canvas2dHeight.current !== props.canvas.height
+        ) {
+          if (divRef.current) {
+            setDivWidth(divRef.current.clientWidth);
+            setDivHeight(divRef.current.clientHeight);
+          }
+          if (props.canvas.width && props.canvas.height) {
+            canvas2dWidth.current = props.canvas.width;
+            canvas2dHeight.current = props.canvas.height;
+            const xRatio =
+              (divRef.current?.clientWidth || 0) / props.canvas.width;
+            const yRatio =
+              (divRef.current?.clientHeight || 0) / props.canvas.height;
+            setRatio(Math.min(xRatio, yRatio));
+          }
         }
-      }
-    }, 50);
-    return () => clearInterval(i);
-  }, [divWidth, divHeight, update]);
+      }, 50);
+      return () => clearInterval(i);
+    }
+  }, [layoutChanging, divWidth, divHeight, update]);
 
   useEffect(() => {
     const update = () => {

--- a/src/components/canvas2DCard.tsx
+++ b/src/components/canvas2DCard.tsx
@@ -18,6 +18,7 @@ import { IconButton } from "./button";
 import { iconFillColor } from "./sideMenu";
 import { Move, Home, Help } from "@icon-park/react";
 import { CaptionBox } from "./caption";
+import { useLayoutChange } from "./layoutChangeProvider";
 
 interface Props {
   canvas: Canvas2D;

--- a/src/components/imageCard.tsx
+++ b/src/components/imageCard.tsx
@@ -2,51 +2,55 @@ import { Card } from "./card";
 import { useForceUpdate } from "../libs/forceUpdate";
 import { Image, imageCompressMode } from "webcface";
 import { useEffect, useRef } from "react";
+import { useLayoutChange } from "./layoutChangeProvider";
 
 interface Props {
   image: Image;
 }
 export function ImageCard(props: Props) {
+  const { layoutChanging } = useLayoutChange();
   const hasUpdate = useRef<boolean>(true);
   const imgRef = useRef<HTMLDivElement>(null);
   const prevImgWidth = useRef<number>(0);
   const prevImgHeight = useRef<number>(0);
   const update = useForceUpdate();
   useEffect(() => {
-    const i = setInterval(() => {
-      if (hasUpdate.current) {
-        update();
-        hasUpdate.current = false;
-      }
-      const ratio = props.image.get().width / props.image.get().height;
-      if (
-        !isNaN(ratio) &&
-        imgRef.current !== null &&
-        (prevImgWidth.current !== imgRef.current.clientWidth ||
-          prevImgHeight.current !== imgRef.current.clientHeight)
-      ) {
-        prevImgWidth.current = imgRef.current.clientWidth;
-        prevImgHeight.current = imgRef.current.clientHeight;
-        const imgRatio = prevImgWidth.current / prevImgHeight.current;
-        let newWidth: number | undefined = undefined,
-          newHeight: number | undefined = undefined;
-        if (ratio > imgRatio) {
-          newWidth = prevImgWidth.current;
-        } else {
-          newHeight = prevImgHeight.current;
+    if (!layoutChanging) {
+      const i = setInterval(() => {
+        if (hasUpdate.current) {
+          update();
+          hasUpdate.current = false;
         }
-        console.log(`re-request ${newWidth} x ${newHeight}`);
-        props.image.request({
-          width: newWidth,
-          height: newHeight,
-          compressMode: imageCompressMode.jpeg,
-          quality: 50,
-          frameRate: 10,
-        });
-      }
-    }, 50);
-    return () => clearInterval(i);
-  }, [props.image, update]);
+        const ratio = props.image.get().width / props.image.get().height;
+        if (
+          !isNaN(ratio) &&
+          imgRef.current !== null &&
+          (prevImgWidth.current !== imgRef.current.clientWidth ||
+            prevImgHeight.current !== imgRef.current.clientHeight)
+        ) {
+          prevImgWidth.current = imgRef.current.clientWidth;
+          prevImgHeight.current = imgRef.current.clientHeight;
+          const imgRatio = prevImgWidth.current / prevImgHeight.current;
+          let newWidth: number | undefined = undefined,
+            newHeight: number | undefined = undefined;
+          if (ratio > imgRatio) {
+            newWidth = prevImgWidth.current;
+          } else {
+            newHeight = prevImgHeight.current;
+          }
+          console.log(`re-request ${newWidth} x ${newHeight}`);
+          props.image.request({
+            width: newWidth,
+            height: newHeight,
+            compressMode: imageCompressMode.jpeg,
+            quality: 50,
+            frameRate: 10,
+          });
+        }
+      }, 50);
+      return () => clearInterval(i);
+    }
+  }, [layoutChanging, props.image, update]);
   useEffect(() => {
     const update = () => {
       hasUpdate.current = true;

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -35,12 +35,14 @@ import { LauncherCard } from "./launcherCard";
 import { useForceUpdate } from "../libs/forceUpdate";
 import { useLocalStorage, LocalStorage } from "./lsProvider";
 import * as cardKey from "../libs/cardKey";
+import { useLayoutChange } from "./layoutChangeProvider";
 
 interface Props {
   client: Client | null;
 }
 
 export function LayoutMain(props: Props) {
+  const { setLayoutChanging } = useLayoutChange();
   const update = useForceUpdate();
   useEffect(() => {
     const onMembersChange = (m: Member) => {
@@ -150,6 +152,10 @@ export function LayoutMain(props: Props) {
       onLayoutChange={onLayoutChange}
       allowOverlap
       draggableHandle=".MyCardHandle"
+      onDragStart={() => setLayoutChanging(true)}
+      onResizeStart={() => setLayoutChanging(true)}
+      onDragStop={() => setLayoutChanging(false)}
+      onResizeStop={() => setLayoutChanging(false)}
     >
       {(() => {
         const key = cardKey.about();

--- a/src/components/layoutChangeProvider.tsx
+++ b/src/components/layoutChangeProvider.tsx
@@ -1,0 +1,20 @@
+import { createContext, ReactElement, useContext, useState } from "react";
+
+interface LayoutChangeData {
+  layoutChanging: boolean;
+  setLayoutChanging: (changing: boolean) => void;
+}
+const LayoutChangeContext = createContext<LayoutChangeData>({
+  layoutChanging: false,
+  setLayoutChanging: () => undefined,
+});
+export const useLayoutChange = () => useContext(LayoutChangeContext);
+
+export function LayoutChangeProvider(props: { children: ReactElement }) {
+  const [layoutChanging, setLayoutChanging] = useState<boolean>(false);
+  return (
+    <LayoutChangeContext.Provider value={{ layoutChanging, setLayoutChanging }}>
+      {props.children}
+    </LayoutChangeContext.Provider>
+  );
+}

--- a/src/components/logCard.tsx
+++ b/src/components/logCard.tsx
@@ -19,28 +19,21 @@ const levelColors = [
 export function LogCard(props: Props) {
   const logStore = useLogStore();
   const logsRef = useRef<LogDataWithLevels>(new LogDataWithLevels()); // 内容はlogStoreと同期される
-  const hasUpdate = useRef<boolean>(false);
-  useEffect(() => {
-    // onScroll();
-    const update = () => {
-      logStore
-        .getDataRef(props.member.name)
-        .log.concat(props.member.log().get());
+  const fetchLog = useCallback(() => {
+    const newLogs = props.member.log().get();
+    if (newLogs.length > 0) {
+      logStore.getDataRef(props.member.name).log.concat(newLogs);
       logsRef.current = logStore.getDataRef(props.member.name).log;
       props.member.log().clear();
-      hasUpdate.current = true;
-    };
-    update();
-    props.member.log().on(update);
-    return () => {
-      props.member.log().off(update);
-    };
+      return true;
+    }
+    return false;
   }, [props.member, logStore]);
 
   return (
     <LogCardImpl
       logsRef={logsRef}
-      hasUpdate={hasUpdate}
+      fetchLog={fetchLog}
       name={props.member.name}
     />
   );
@@ -50,7 +43,7 @@ export function LogCardServer() {
   return (
     <LogCardImpl
       logsRef={logStore.serverData}
-      hasUpdate={logStore.serverHasUpdate}
+      fetchLog={() => logStore.serverHasUpdate.current}
       name={"webcface server"}
     />
   );
@@ -58,12 +51,12 @@ export function LogCardServer() {
 
 interface Props2 {
   logsRef: { current: LogDataWithLevels };
-  hasUpdate: { current: boolean };
+  fetchLog: () => boolean; // logをチェックしてlogsRefに反映し、更新されていたらtrueを返す
   name: string;
 }
 const lineHeight = 24;
 function LogCardImpl(props: Props2) {
-  const { logsRef, hasUpdate, name } = props;
+  const { logsRef, fetchLog, name } = props;
   // 引数のlogsRefは高頻度で更新されるが、以下のstateは50msに1回更新される
   // const [logLine, setLogLine] = useState<number>(0);
   const [logsCurrent, setLogsCurrent] = useState<LogLine[]>([]);
@@ -112,16 +105,18 @@ function LogCardImpl(props: Props2) {
           logsDiv.current.scrollTo(0, lineHeight * logsCurrent.length);
         }
       });
-      hasUpdate.current = false;
+      // hasUpdate.current = false;
     };
     updateLogsCurrent();
     const i = setInterval(() => {
-      if (hasUpdate.current && followRealTime) {
-        updateLogsCurrent();
+      if (followRealTime) {
+        if (fetchLog()) {
+          updateLogsCurrent();
+        }
       }
     }, 50);
     return () => clearInterval(i);
-  }, [minLevel, hasUpdate, logsRef, followRealTime]);
+  }, [minLevel, fetchLog, logsRef, followRealTime]);
 
   return (
     <Card title={`${name} Logs`}>

--- a/src/components/logCard.tsx
+++ b/src/components/logCard.tsx
@@ -1,5 +1,5 @@
 import { Card } from "./card";
-import { Member, LogLine, Log } from "webcface";
+import { Member, LogLine } from "webcface";
 import { useState, useEffect, useRef, useCallback } from "react";
 import { format } from "date-fns";
 import { LogDataWithLevels, useLogStore } from "./logStoreProvider";

--- a/src/components/sideMenu.tsx
+++ b/src/components/sideMenu.tsx
@@ -220,15 +220,15 @@ function SideMenuMember(props: MemberProps) {
     const update = () => {
       setTextNum(props.member.texts().length);
       setFuncNum(props.member.funcs().length);
-      // setHasLog(
-      //   props.member.log().get().length > 0 ||
-      //     logStore.data.current.find((ld) => ld.name === props.member.name) !==
-      //       undefined
-      // );
+      setHasLog(
+        props.member.log().exists() ||
+          logStore.data.current.find((ld) => ld.name === props.member.name) !==
+            undefined
+      );
     };
     const i = setInterval(update, 100);
     return () => clearInterval(i);
-  }, [props.member]);
+  }, [props.member, logStore.data]);
   useEffect(() => {
     const valueNames: FieldGroup[] = [];
     const sortValueNames = (

--- a/src/components/sideMenu.tsx
+++ b/src/components/sideMenu.tsx
@@ -215,16 +215,16 @@ function SideMenuMember(props: MemberProps) {
   const [valueNames, setValueNames] = useState<FieldGroup[]>([]);
   const [textNum, setTextNum] = useState<number>(0);
   const [funcNum, setFuncNum] = useState<number>(0);
-  const [hasLog, setHasLog] = useState<boolean>(false);
+  const [hasLog, setHasLog] = useState<boolean>(true);
   useEffect(() => {
     const update = () => {
       setTextNum(props.member.texts().length);
       setFuncNum(props.member.funcs().length);
-      setHasLog(
-        props.member.log().get().length > 0 ||
-          logStore.data.current.find((ld) => ld.name === props.member.name) !==
-            undefined
-      );
+      // setHasLog(
+      //   props.member.log().get().length > 0 ||
+      //     logStore.data.current.find((ld) => ld.name === props.member.name) !==
+      //       undefined
+      // );
     };
     const i = setInterval(update, 100);
     return () => clearInterval(i);

--- a/src/components/valueCard.tsx
+++ b/src/components/valueCard.tsx
@@ -15,6 +15,7 @@ import { Help, Home, Move } from "@icon-park/react";
 import { iconFillColor } from "./sideMenu";
 import { CaptionBox } from "./caption";
 import { useForceUpdate } from "../libs/forceUpdate";
+import { useLayoutChange } from "./layoutChangeProvider";
 
 interface Props {
   value: Value;
@@ -23,6 +24,7 @@ interface Props {
 const maxXRange = 5000; // ms
 
 export function ValueCard(props: Props) {
+  const { layoutChanging } = useLayoutChange();
   const canvasMain = useRef<HTMLCanvasElement>(null);
   const canvasDiv = useRef<HTMLDivElement>(null);
   const hasUpdate = useRef<boolean>(true);
@@ -93,14 +95,16 @@ export function ValueCard(props: Props) {
   };
 
   useEffect(() => {
-    const i = setInterval(() => {
-      if (hasUpdate.current) {
-        update();
-        hasUpdate.current = false;
-      }
-    }, 50);
-    return () => clearInterval(i);
-  }, [update]);
+    if (!layoutChanging) {
+      const i = setInterval(() => {
+        if (hasUpdate.current) {
+          update();
+          hasUpdate.current = false;
+        }
+      }, 50);
+      return () => clearInterval(i);
+    }
+  }, [layoutChanging, update]);
 
   // dataの追加
   useEffect(() => {
@@ -139,7 +143,7 @@ export function ValueCard(props: Props) {
     );
     line.arrangeX();
 
-    if (canvasMain.current) {
+    if (canvasMain.current && !layoutChanging) {
       let id = 0;
       let renderPlot = () => {
         if (canvasMain.current == null || canvasDiv.current == null) {
@@ -218,7 +222,7 @@ export function ValueCard(props: Props) {
         cancelAnimationFrame(id);
       };
     }
-  }, []);
+  }, [layoutChanging]);
 
   // カーソルを乗せた位置の値を表示する用
   const [cursorPosXRaw, setCursorPosXRaw] = useState<number | null>(null);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,15 +4,18 @@ import App from "./App";
 import { FuncResultProvider } from "./components/funcResultProvider";
 import { LocalStorageProvider } from "./components/lsProvider";
 import { LogStoreProvider } from "./components/logStoreProvider";
-import '@fontsource/noto-mono';
-import '@fontsource/noto-sans';
+import "@fontsource/noto-mono";
+import "@fontsource/noto-sans";
+import { LayoutChangeProvider } from "./components/layoutChangeProvider";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <FuncResultProvider>
       <LocalStorageProvider>
         <LogStoreProvider>
-          <App />
+          <LayoutChangeProvider>
+            <App />
+          </LayoutChangeProvider>
         </LogStoreProvider>
       </LocalStorageProvider>
     </FuncResultProvider>


### PR DESCRIPTION
* Log画面を開いていなくてもLogを受信していたのを修正
* 受信したLogの処理をコールバックで行うのではなく50msごとのインターバルでおこなうようにする
* 50msあたり1000行以上のログは読まないようにする
  * todo: 表示がレベルごと1000行なのに対して読み込みは全レベル合計1000行の制限になってしまっているが?
* LogCardの処理がこれで軽くなるかと思ったが、<del>あまり変わらんかった</del> 若干改善してそうだけど、誤差かも
* layoutの操作中はlog,value,canvas,imageを再描画しないようにした

todo:
* [x] server側にLogEntryメッセージが必要。 https://github.com/na-trium-144/webcface-js/pull/187 https://github.com/na-trium-144/webcface/pull/397
* [x] jsクライアントでlog()が保持するログの行数を制限する機能 https://github.com/na-trium-144/webcface-js/pull/188 https://github.com/na-trium-144/webcface/pull/398